### PR TITLE
fixed Config::get invalid keypath

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,5 +1,6 @@
 #include "config-cxx/Config.h"
 
+#include <cstddef>
 #include <iostream>
 #include <stdexcept>
 
@@ -29,32 +30,9 @@ T Config::get(const std::string& keyPath)
         throw std::runtime_error("Config key " + keyPath + " not found.");
     }
 
-    if constexpr (std::is_same_v<T, std::string>)
+    if (value.type() == typeid(std::nullptr_t))
     {
-        // Check if the value is nullptr before casting
-        if (value.type() == typeid(std::nullptr_t))
-        {
-            // Handle nullptr case by returning an empty string
-            return std::string();
-        }
-    }
-    else if constexpr (std::is_same_v<T, int>)
-    {
-        // Check if the value is nullptr before casting
-        if (value.type() == typeid(std::nullptr_t))
-        {
-            // Handle nullptr case for int
-            return 0;
-        }
-    }
-    else if constexpr (std::is_same_v<T, bool>)
-    {
-        // Check if the value is nullptr before casting
-        if (value.type() == typeid(std::nullptr_t))
-        {
-            // Handle nullptr case for bool
-            return false;
-        }
+        throw std::runtime_error("Config key " + keyPath + " is of invalid nullptr type.");
     }
 
     try

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -34,8 +34,26 @@ T Config::get(const std::string& keyPath)
         // Check if the value is nullptr before casting
         if (value.type() == typeid(std::nullptr_t))
         {
-            // Handle nullptr case by returning an empty string or another default value
-            return std::string(); // or return ""; or return someDefaultValue;
+            // Handle nullptr case by returning an empty string
+            return std::string();
+        }
+    }
+    else if constexpr (std::is_same_v<T, int>)
+    {
+        // Check if the value is nullptr before casting
+        if (value.type() == typeid(std::nullptr_t))
+        {
+            // Handle nullptr case for int
+            return 0;
+        }
+    }
+    else if constexpr (std::is_same_v<T, bool>)
+    {
+        // Check if the value is nullptr before casting
+        if (value.type() == typeid(std::nullptr_t))
+        {
+            // Handle nullptr case for bool
+            return false;
         }
     }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -64,7 +64,7 @@ T Config::get(const std::string& keyPath)
     catch (const std::bad_any_cast& e)
     {
         // Log the error details
-        std::cerr << "Error casting value for Config key '" << keyPath << "': " << e.what() << std::endl;
+        std::cerr << "Cannot resolve value for config key '" << keyPath << "': " << e.what() << std::endl;
         throw; // Re-throw the exception
     }
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -31,16 +31,24 @@ T Config::get(const std::string& keyPath)
 
     if constexpr (std::is_same_v<T, std::string>)
     {
-        try
+        // Check if the value is nullptr before casting
+        if (value.type() == typeid(std::nullptr_t))
         {
-            return std::to_string(std::any_cast<int>(value));
-        }
-        catch (const std::bad_any_cast& e)
-        {
+            // Handle nullptr case by returning an empty string or another default value
+            return std::string(); // or return ""; or return someDefaultValue;
         }
     }
 
-    return std::any_cast<T>(value);
+    try
+    {
+        return std::any_cast<T>(value);
+    }
+    catch (const std::bad_any_cast& e)
+    {
+        // Log the error details
+        std::cerr << "Error casting value for Config key '" << keyPath << "': " << e.what() << std::endl;
+        throw; // Re-throw the exception
+    }
 }
 
 std::any Config::get(const std::string& keyPath)
@@ -50,8 +58,8 @@ std::any Config::get(const std::string& keyPath)
         initialize();
     }
 
-    const auto keyOccurrences = std::count_if(values.begin(), values.end(), [&](auto& value)
-                                              { return value.first.find(keyPath) != std::string::npos; });
+    const auto keyOccurrences = std::count_if(
+        values.begin(), values.end(), [&](auto& value) { return value.first.find(keyPath) != std::string::npos; });
 
     if (keyOccurrences == 0)
     {

--- a/src/ConfigDirectoryPathResolverTest.cpp
+++ b/src/ConfigDirectoryPathResolverTest.cpp
@@ -79,12 +79,10 @@ public:
 
 TEST_F(ConfigDirectoryPathResolverTest, givenNotExistingPathInConfigDirectory_throws)
 {
-    const auto configDirectoryEnvName = "CXX_CONFIG_DIR";
+    // Set CXX_CONFIG_DIR to a non-existing path
+    EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", "/nonexistent/path");
 
-    const auto notExistingConfigDirectoryPath = "test";
-
-    EnvironmentSetter::setEnvironmentVariable(configDirectoryEnvName, notExistingConfigDirectoryPath);
-
+    // Now calling getConfigDirectoryPath should throw an exception
     ASSERT_THROW(ConfigDirectoryPathResolver::getConfigDirectoryPath(), std::runtime_error);
 }
 


### PR DESCRIPTION
Changed Config::get(const std::string& keyPath) to check if value is nullptr before casting Also changed ConfigDirectoryPathResolverTest::givenNotExistingPathInConfigDirectory_throws to make sure there's a nonexistent path