### PR TITLE
Using std::variant instead of std::any

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(UT_SOURCES
     src/filesystem/ExecutableFinderTest.cpp
     src/tests/EnvironmentSetter.cpp
     src/tests/EnvironmentSetterTest.cpp
+    src/JsonConfigLoaderTest.cpp
 )
 
 add_library(${LIBRARY_NAME} ${SOURCES})

--- a/include/config-cxx/Config.h
+++ b/include/config-cxx/Config.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <any>
+#include <variant>
 #include <functional>
 #include <optional>
 #include <string>
@@ -9,6 +9,8 @@
 
 namespace config
 {
+using ConfigValue = std::variant<std::nullptr_t, bool, int, double, std::string, float, std::vector<std::string>>;
+
 class Config
 {
 public:
@@ -41,7 +43,7 @@ public:
      * Config().get("db.port") // 3306
      * @endcode
      */
-    std::any get(const std::string& keyPath);
+    ConfigValue get(const std::string& keyPath);
 
     /**
      * @brief Check if a config key exists.
@@ -63,6 +65,6 @@ private:
 
     bool initialized = false;
 
-    std::unordered_map<std::string, std::any> values;
+    std::unordered_map<std::string, ConfigValue> values;
 };
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -20,7 +20,18 @@ T Config::get(const std::string& keyPath)
         initialize();
     }
 
-    const auto value = values[keyPath];
+    if constexpr (std::is_same_v<T, std::vector<std::string>>)
+    {
+        return getArray(keyPath);
+    }
+
+    auto it = values.find(keyPath);
+    if (it == values.end())
+    {
+        throw std::runtime_error("Config key " + keyPath + " not found.");
+    }
+
+    const auto& value = it->second;
 
     if (value.index() == 0)
     {

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -200,7 +200,7 @@ TEST_F(ConfigTest, givenCxxEnvAndConfigDir_returnsKeyValues)
     ASSERT_EQ(authExpiresInValue, 3600);
     ASSERT_EQ(authEnabledValue, true);
     ASSERT_EQ(authRolesValue, expectedAuthRoles);
-};
+}
 
 TEST_F(ConfigTest, givenNoCxxEnvAndNoConfigDir_returnsDevelopmentKeyValues)
 {
@@ -234,7 +234,7 @@ TEST_F(ConfigTest, givenNoCxxEnvAndNoConfigDir_returnsDevelopmentKeyValues)
     ASSERT_EQ(authExpiresInValue, 7200);
     ASSERT_EQ(authEnabledValue, false);
     ASSERT_EQ(authRolesValue, expectedAuthRoles);
-};
+}
 
 TEST_F(ConfigTest, givenConfigDirWithoutConfigFiles_shouldThrow)
 {
@@ -243,7 +243,7 @@ TEST_F(ConfigTest, givenConfigDirWithoutConfigFiles_shouldThrow)
     Config config;
 
     ASSERT_THROW(config.get<std::string>("example.key"), std::runtime_error);
-};
+}
 
 TEST_F(ConfigTest, givenCxxEnvAndConfigDirAndNotExistingKey_shouldThrow)
 {
@@ -254,50 +254,7 @@ TEST_F(ConfigTest, givenCxxEnvAndConfigDirAndNotExistingKey_shouldThrow)
 
     const std::string notExistingKey = "not.existing.key";
 
-    ASSERT_THROW(config.get<int>(notExistingKey), std::runtime_error);
-}
-
-TEST_F(ConfigTest, returnsKeyValueAsAny)
-{
-    EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
-    EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", testConfigDirectory.string());
-
-    const auto awsAccountId = "9999999999";
-    const auto awsAccountKey = "806223445";
-
-    EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_ID", awsAccountId);
-    EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_KEY", awsAccountKey);
-
-    Config config;
-
-    const std::string dbHostKey = "db.host";
-    const std::string dbPortKey = "db.port";
-    const std::string awsAccountIdKey = "aws.accountId";
-    const std::string awsAccountKeyKey = "aws.accountKey";
-    const std::string awsRegionKey = "aws.region";
-    const std::string authExpiresInKey = "auth.expiresIn";
-    const std::string authEnabledKey = "auth.enabled";
-    const std::string authRolesKey = "auth.roles";
-
-    const auto dbHostValue = config.get(dbHostKey);
-    const auto dbPortValue = config.get(dbPortKey);
-    const auto awsAccountIdValue = config.get<std::string>(awsAccountIdKey);
-    const auto awsAccountKeyValue = config.get<std::string>(awsAccountKeyKey);
-    const auto awsRegionValue = config.get<std::string>(awsRegionKey);
-    const auto authExpiresInValue = config.get<int>(authExpiresInKey);
-    const auto authEnabledValue = config.get<bool>(authEnabledKey);
-    const auto authRolesValue = config.get<std::vector<std::string>>(authRolesKey);
-
-    const auto expectedAuthRoles = std::vector<std::string>{"admin", "user"};
-
-    ASSERT_EQ(std::any_cast<std::string>(dbHostValue), "localhost");
-    ASSERT_EQ(std::any_cast<int>(dbPortValue), 1996);
-    ASSERT_EQ(std::any_cast<std::string>(awsAccountIdValue), awsAccountId);
-    ASSERT_EQ(std::any_cast<std::string>(awsAccountKeyValue), awsAccountKey);
-    ASSERT_EQ(std::any_cast<std::string>(awsRegionValue), "eu-west-1");
-    ASSERT_EQ(std::any_cast<int>(authExpiresInValue), 3600);
-    ASSERT_EQ(std::any_cast<bool>(authEnabledValue), true);
-    ASSERT_EQ(std::any_cast<std::vector<std::string>>(authRolesValue), expectedAuthRoles);
+    ASSERT_THROW(config.get<int>(notExistingKey), std::bad_variant_access);
 }
 
 TEST_F(ConfigTest, getAny_givenNotExistingKey_shouldThrow)

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <stdexcept>
 
 #include "gtest/gtest.h"
 
@@ -254,7 +255,7 @@ TEST_F(ConfigTest, givenCxxEnvAndConfigDirAndNotExistingKey_shouldThrow)
 
     const std::string notExistingKey = "not.existing.key";
 
-    ASSERT_THROW(config.get<int>(notExistingKey), std::bad_variant_access);
+    ASSERT_THROW(config.get<int>(notExistingKey), std::runtime_error);
 }
 
 TEST_F(ConfigTest, getAny_givenNotExistingKey_shouldThrow)

--- a/src/ConfigValue.h
+++ b/src/ConfigValue.h
@@ -1,0 +1,122 @@
+#include <cmath>
+#include <iomanip>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace details
+{
+template <typename T>
+int findDecimal(T const& t)
+{
+    int count = 0;
+    T cp = t;
+    while (static_cast<int>(std::floor(cp)) != static_cast<int>(cp))
+    {
+        cp *= 10;
+        count++;
+    }
+
+    return count;
+}
+
+template <typename T>
+std::optional<std::string> to_string(T const& t)
+{
+    if constexpr (std::is_same_v<T, std::nullptr_t>)
+    {
+        return "nullptr";
+    }
+    else if constexpr (std::is_same_v<T, std::string>)
+    {
+        return t;
+    }
+    else if constexpr (std::is_same_v<T, std::vector<std::string>>)
+    {
+        std::string result = "[";
+        for (const auto& str : t)
+        {
+            result += "\"" + str + "\", ";
+        }
+        if (!t.empty())
+        {
+            result.pop_back();
+            result.pop_back(); // Remove the trailing comma and space
+        }
+        result += "]";
+        return result;
+    }
+    else if constexpr (std::is_floating_point_v<T>)
+    {
+        // Calculate precision dynamically based on the input value
+        int precision = findDecimal(t);
+
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(precision) << t;
+        return oss.str();
+    }
+    else
+    {
+        std::ostringstream oss;
+        oss << t;
+        return oss.str();
+    }
+}
+
+template <typename T>
+std::optional<std::vector<std::string>> to_vector(const T& t)
+{
+    if constexpr (std::is_same_v<T, std::vector<std::string>>)
+        return t;
+
+    std::vector<std::string> result;
+
+    auto strOption = details::to_string(t);
+
+    if (strOption.has_value())
+    {
+        result.push_back(*strOption);
+        return result;
+    }
+
+    else
+    {
+        return std::nullopt;
+    }
+}
+
+template <typename T, typename U>
+std::optional<T> to_optional(U const& u)
+{
+    if constexpr (std::is_constructible_v<T, U const&>)
+        return static_cast<T>(u);
+    else
+        return std::nullopt;
+}
+}
+
+namespace config
+{
+using ConfigValue = std::variant<std::nullptr_t, bool, int, double, std::string, float, std::vector<std::string>>;
+
+template <typename T>
+std::optional<T> cast(ConfigValue const& cv)
+{
+    return std::visit([](auto const& value) { return details::to_optional<T>(value); }, cv);
+}
+
+template <>
+std::optional<std::string> cast<std::string>(ConfigValue const& cv)
+{
+    return std::visit([](auto const& value) { return details::to_string(value); }, cv);
+}
+
+template <>
+std::optional<std::vector<std::string>> cast<std::vector<std::string>>(ConfigValue const& cv)
+{
+    return std::visit([](auto const& value) { return details::to_vector(value); }, cv);
+}
+
+} // namespace config

--- a/src/JsonConfigLoader.cpp
+++ b/src/JsonConfigLoader.cpp
@@ -118,4 +118,3 @@ ConfigValue normalizeConfigValue(const nlohmann::json& jsonObject)
 }
 }
 } // namespace config
-

--- a/src/JsonConfigLoader.cpp
+++ b/src/JsonConfigLoader.cpp
@@ -1,6 +1,7 @@
 #include "JsonConfigLoader.h"
 
 #include <iostream>
+#include <variant>
 
 #include "environment/EnvironmentParser.h"
 #include "filesystem/FileSystemService.h"
@@ -11,11 +12,11 @@ namespace config
 namespace
 {
 std::string normalizeConfigKey(const std::string& str);
-std::any normalizeConfigValue(const nlohmann::json& jsonObject);
+ConfigValue normalizeConfigValue(const nlohmann::json& jsonObject);
 }
 
 void JsonConfigLoader::loadConfigFile(const std::filesystem::path& configFilePath,
-                                      std::unordered_map<std::string, std::any>& configValues)
+                                      std::unordered_map<std::string, ConfigValue>& configValues)
 {
     const auto configFileExists = filesystem::FileSystemService::exists(configFilePath);
 
@@ -41,7 +42,7 @@ void JsonConfigLoader::loadConfigFile(const std::filesystem::path& configFilePat
 }
 
 void JsonConfigLoader::loadConfigEnvFile(const std::filesystem::path& configFilePath,
-                                         std::unordered_map<std::string, std::any>& configValues)
+                                         std::unordered_map<std::string, ConfigValue>& configValues)
 {
     const auto configFileExists = filesystem::FileSystemService::exists(configFilePath);
 
@@ -84,9 +85,9 @@ std::string normalizeConfigKey(const std::string& str)
     return result;
 }
 
-std::any normalizeConfigValue(const nlohmann::json& jsonObject)
+ConfigValue normalizeConfigValue(const nlohmann::json& jsonObject)
 {
-    std::any normalizedValue;
+    ConfigValue normalizedValue;
 
     if (jsonObject.is_string())
     {
@@ -116,5 +117,5 @@ std::any normalizeConfigValue(const nlohmann::json& jsonObject)
     return normalizedValue;
 }
 }
+} // namespace config
 
-}

--- a/src/JsonConfigLoader.h
+++ b/src/JsonConfigLoader.h
@@ -1,18 +1,20 @@
 #pragma once
 
-#include <any>
 #include <filesystem>
 #include <string>
 #include <unordered_map>
+#include <variant>
 
 namespace config
 {
+using ConfigValue = std::variant<std::nullptr_t, bool, int, double, std::string, float, std::vector<std::string>>;
+
 class JsonConfigLoader
 {
 public:
     static void loadConfigFile(const std::filesystem::path& configFilePath,
-                               std::unordered_map<std::string, std::any>& configValues);
+                               std::unordered_map<std::string, ConfigValue>& configValues);
     static void loadConfigEnvFile(const std::filesystem::path& configFilePath,
-                                  std::unordered_map<std::string, std::any>& configValues);
+                                  std::unordered_map<std::string, ConfigValue>& configValues);
 };
 };

--- a/src/JsonConfigLoader.h
+++ b/src/JsonConfigLoader.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 namespace config
 {

--- a/src/JsonConfigLoaderTest.cpp
+++ b/src/JsonConfigLoaderTest.cpp
@@ -1,10 +1,9 @@
 #include "JsonConfigLoader.h"
-#include "config-cxx/Config.h"
 
 #include <filesystem>
 #include <fstream>
 #include <unordered_map>
-#include <any>
+#include <variant>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -76,7 +75,7 @@ class JsonConfigLoaderTest : public Test
 TEST_F(JsonConfigLoaderTest, loadConfigFile) {
     std::unordered_map<std::string, std::any> expectedValues = {
         {"db.port", 1996},
-        {"aws.accountId", "123456789012"},
+        {"aws.accountId", "123"},
         {"aws.accountKey", "123"},
         {"aws.region", "eu-central-1"},
         {"auth.expiresIn", 3600},
@@ -85,6 +84,7 @@ TEST_F(JsonConfigLoaderTest, loadConfigFile) {
         {"auth.roles.1", "user"}
     };
 
-    std::unordered_map<std::string, std::any> configValues;
+    std::unordered_map<std::string, ConfigValue> configValues;
     JsonConfigLoader::loadConfigFile(testEnvConfigFilePath, configValues);
+
 }

--- a/src/JsonConfigLoaderTest.cpp
+++ b/src/JsonConfigLoaderTest.cpp
@@ -1,0 +1,90 @@
+#include "JsonConfigLoader.h"
+#include "config-cxx/Config.h"
+
+#include <filesystem>
+#include <fstream>
+#include <unordered_map>
+#include <any>
+#include <string>
+#include <vector>
+#include <iostream>
+
+#include "gtest/gtest.h"
+
+#include "filesystem/ExecutableFinder.h"
+#include "tests/EnvironmentSetter.h"
+
+using namespace ::testing;
+using namespace config;
+using namespace config::tests;
+using namespace config::filesystem;
+
+namespace
+{
+const auto projectRootPath = ExecutableFinder::getExecutablePath();
+const auto testConfigDirectory = projectRootPath.parent_path() / "testConfig";
+const auto testEnvConfigFilePath = testConfigDirectory / "test.json";
+
+const std::string testJson = R"(
+{
+    "db": {
+        "port": 1996
+    },
+    "aws": {
+        "accountId": "123456789012",
+        "accountKey": "123",
+        "region": "eu-central-1"
+    },
+    "auth": {
+        "expiresIn": 3600,
+        "enabled": true,
+        "roles": [
+            "admin",
+            "user"
+        ]
+    }
+}
+)";
+}
+
+class JsonConfigLoaderTest : public Test
+{
+    public:
+    void SetUp() override
+    {
+        EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
+        EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", testConfigDirectory.string());
+
+        std::filesystem::remove_all(testConfigDirectory);
+
+        std::filesystem::create_directory(testConfigDirectory);
+
+        std::ofstream testEnvConfigFile{testEnvConfigFilePath};
+
+        testEnvConfigFile << testJson;
+    }
+
+    void TearDown() override
+    {
+        EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
+        EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", testConfigDirectory.string());
+
+        std::filesystem::remove_all(testConfigDirectory);
+    }
+};
+
+TEST_F(JsonConfigLoaderTest, loadConfigFile) {
+    std::unordered_map<std::string, std::any> expectedValues = {
+        {"db.port", 1996},
+        {"aws.accountId", "123456789012"},
+        {"aws.accountKey", "123"},
+        {"aws.region", "eu-central-1"},
+        {"auth.expiresIn", 3600},
+        {"auth.enabled", true},
+        {"auth.roles.0", "admin"},
+        {"auth.roles.1", "user"}
+    };
+
+    std::unordered_map<std::string, std::any> configValues;
+    JsonConfigLoader::loadConfigFile(testEnvConfigFilePath, configValues);
+}

--- a/src/JsonConfigLoaderTest.cpp
+++ b/src/JsonConfigLoaderTest.cpp
@@ -2,14 +2,15 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iostream>
+#include <string>
 #include <unordered_map>
 #include <variant>
-#include <string>
 #include <vector>
-#include <iostream>
 
 #include "gtest/gtest.h"
 
+#include "config-cxx/Config.h"
 #include "filesystem/ExecutableFinder.h"
 #include "tests/EnvironmentSetter.h"
 
@@ -25,16 +26,12 @@ using ConfigValue = std::variant<std::nullptr_t, bool, int, double, std::string,
 const auto projectRootPath = ExecutableFinder::getExecutablePath();
 const auto testConfigDirectory = projectRootPath.parent_path() / "testConfig";
 const auto testEnvConfigFilePath = testConfigDirectory / "test.json";
+const auto customEnvironmentsConfigFilePath = testConfigDirectory / "custom-environment-variables.json";
 
 const std::string testJson = R"(
 {
     "db": {
         "port": 1996
-    },
-    "aws": {
-        "accountId": "123456789012",
-        "accountKey": "123",
-        "region": "eu-central-1"
     },
     "auth": {
         "expiresIn": 3600,
@@ -46,15 +43,25 @@ const std::string testJson = R"(
     }
 }
 )";
+
+const std::string envVariablesJson = R"(
+{
+    "aws": {
+        "accountId": "AWS_ACCOUNT_ID",
+        "accountKey": "AWS_ACCOUNT_KEY"
+    }
 }
+)";
 
 class JsonConfigLoaderTest : public Test
 {
-    public:
+public:
     void SetUp() override
     {
-        EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
-        EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", testConfigDirectory.string());
+        EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "");
+        EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", "");
+        EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_ID", "");
+        EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_KEY", "");
 
         std::filesystem::remove_all(testConfigDirectory);
 
@@ -63,30 +70,73 @@ class JsonConfigLoaderTest : public Test
         std::ofstream testEnvConfigFile{testEnvConfigFilePath};
 
         testEnvConfigFile << testJson;
+
+        std::ofstream customEnvironmentsConfigFile{customEnvironmentsConfigFilePath};
+
+        customEnvironmentsConfigFile << envVariablesJson;
     }
 
     void TearDown() override
     {
         EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
         EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", testConfigDirectory.string());
+        EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_ID", "");
+        EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_KEY", "");
 
         std::filesystem::remove_all(testConfigDirectory);
     }
 };
 
-TEST_F(JsonConfigLoaderTest, loadConfigFile) {
-    std::unordered_map<std::string, ConfigValue> expectedValues = {
-        {"db.port", 1996},
-        {"aws.accountId", "123"},
-        {"aws.accountKey", "123"},
-        {"aws.region", "eu-central-1"},
-        {"auth.expiresIn", 3600},
-        {"auth.enabled", true},
-        {"auth.roles.0", "admin"},
-        {"auth.roles.1", "user"}
-    };
+TEST_F(JsonConfigLoaderTest, loadConfigFile)
+{
+    EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
+    EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", testConfigDirectory.string());
+
+    std::unordered_map<std::string, ConfigValue> expectedValues = {{"db.port", 1996},
+                                                                   {"auth.expiresIn", 3600},
+                                                                   {"auth.enabled", true},
+                                                                   {"auth.roles.0", "admin"},
+                                                                   {"auth.roles.1", "user"}};
 
     std::unordered_map<std::string, ConfigValue> configValues;
     JsonConfigLoader::loadConfigFile(testEnvConfigFilePath, configValues);
 
+    for (const auto& [key, value] : expectedValues)
+    {
+        auto it = configValues.find(key);
+        ASSERT_NE(it, configValues.end());
+        EXPECT_EQ(it->second, value);
+    }
 }
+
+TEST_F(JsonConfigLoaderTest, loadConfigFileWithEnv)
+{
+    // Set up environment variables and paths
+    EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
+    EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", customEnvironmentsConfigFilePath.string());
+    const auto awsAccountId = "9999999999";
+    const auto awsAccountKey = "806223445";
+    EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_ID", awsAccountId);
+    EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_KEY", awsAccountKey);
+
+    // Define expected values after environment variable overrides
+    std::unordered_map<std::string, ConfigValue> expectedValues = {
+        {"aws.accountId", awsAccountId},
+        {"aws.accountKey", awsAccountKey},
+    };
+
+    // Load configuration using JsonConfigLoader
+    std::unordered_map<std::string, ConfigValue> configValues;
+    JsonConfigLoader::loadConfigEnvFile(customEnvironmentsConfigFilePath, configValues);
+
+    // Verify that the loaded values match the expected values
+    for (const auto& [key, expectedValue] : expectedValues)
+    {
+        auto it = configValues.find(key);
+        ASSERT_NE(it, configValues.end()) << "Key: " << key << " not found in configValues.";
+
+        // Check the actual value against the expected value
+        EXPECT_EQ(it->second, expectedValue) << "Mismatch for key: " << key;
+    }
+}
+} // namespace

--- a/src/JsonConfigLoaderTest.cpp
+++ b/src/JsonConfigLoaderTest.cpp
@@ -20,6 +20,8 @@ using namespace config::filesystem;
 
 namespace
 {
+using ConfigValue = std::variant<std::nullptr_t, bool, int, double, std::string, float, std::vector<std::string>>;
+
 const auto projectRootPath = ExecutableFinder::getExecutablePath();
 const auto testConfigDirectory = projectRootPath.parent_path() / "testConfig";
 const auto testEnvConfigFilePath = testConfigDirectory / "test.json";
@@ -73,7 +75,7 @@ class JsonConfigLoaderTest : public Test
 };
 
 TEST_F(JsonConfigLoaderTest, loadConfigFile) {
-    std::unordered_map<std::string, std::any> expectedValues = {
+    std::unordered_map<std::string, ConfigValue> expectedValues = {
         {"db.port", 1996},
         {"aws.accountId", "123"},
         {"aws.accountKey", "123"},


### PR DESCRIPTION
I've talked about it in the discord but I'll talk about it again here oh well

There are only a select few types that the `get` functions use, these types are `int`, `bool`, `float`, `double`, `std::string`, and `std::vector<std::string>`.
Instead of using `std::any` which can be any type and makes logical comparisons very tough and is easier to implement in the get functions but hurt in the long run. We can use our own ConfigValue which is an `std::variant` of the types I previously listed that would make the code easier to contribute on and maintain (will have comparisons and easier access than `std::any`) 

I added these helper functions in a ConfigValue.h helper file. 