### PR TITLE
Added support for getting optional value #33

### DIFF
--- a/include/config-cxx/Config.h
+++ b/include/config-cxx/Config.h
@@ -33,6 +33,23 @@ public:
     T get(const std::string& keyPath);
 
     /**
+     * @brief Get a config value by path if it exists.
+     *
+     * @tparam T The target type of config value.
+     *
+     * @param path The path to config key.
+     *
+     * @return The value of config key casted to provided type or std::nullopt.
+     *
+     * @code
+     * Config().getOptional<std::string>("db.host") // "localhost"
+     * Config().getOptional<int>("db.port") // 3306
+     * @endcode
+     */
+    template <typename T>
+    std::optional<T> getOptional(const std::string& keyPath);
+
+    /**
      * @brief Get a config value by path.
      *
      * @param path The path to config key.

--- a/include/config-cxx/Config.h
+++ b/include/config-cxx/Config.h
@@ -44,6 +44,7 @@ public:
      * @code
      * Config().getOptional<std::string>("db.host") // "localhost"
      * Config().getOptional<int>("db.port") // 3306
+     * Config().getOptional<std::string>("redis.host") // std::nullopt
      * @endcode
      */
     template <typename T>

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -82,7 +82,7 @@ std::optional<T> Config::getOptional(const std::string& keyPath)
 
     if (value.index() == 0)
     {
-        throw std::runtime_error("Config key " + keyPath + " has value of nullptr.");
+        return std::nullopt;
     }
 
     std::optional<T> castedValue = config::cast<T>(value);

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -268,4 +268,10 @@ template bool Config::get<bool>(const std::string&);
 template std::string Config::get<std::string>(const std::string&);
 template std::vector<std::string> Config::get<std::vector<std::string>>(const std::string&);
 template float Config::get<float>(const std::string&);
+
+template std::optional<int> Config::getOptional<int>(const std::string&);
+template std::optional<bool> Config::getOptional<bool>(const std::string&);
+template std::optional<std::string> Config::getOptional<std::string>(const std::string&);
+template std::optional<std::vector<std::string>> Config::getOptional<std::vector<std::string>>(const std::string&);
+template std::optional<float> Config::getOptional<float>(const std::string&);
 }

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -1,6 +1,7 @@
 #include "config-cxx/Config.h"
 
 #include <filesystem>
+#include <optional>
 #include <fstream>
 #include <stdexcept>
 
@@ -448,9 +449,9 @@ TEST_F(ConfigTest, givenCxxEnvAndConfigDir_returnsOptionalKeyValues)
     const auto awsAccountKeyValue = config.getOptional<std::string>(awsAccountKeyKey);
     const auto nonExistantKeyValue = config.getOptional<std::string>(nonExistantKey);
 
-    ASSERT_EQ(dbHostValue, "localhost");
-    ASSERT_EQ(dbPortValue, 1996);
-    ASSERT_EQ(awsAccountIdValue, awsAccountId);
-    ASSERT_EQ(awsAccountKeyValue, awsAccountKey);
-    ASSERT_EQ(nonExistantKeyValue, std::nullopt);
+    ASSERT_EQ(*dbHostValue, "localhost");
+    ASSERT_EQ(*dbPortValue, 1996);
+    ASSERT_EQ(*awsAccountIdValue, awsAccountId);
+    ASSERT_EQ(*awsAccountKeyValue, awsAccountKey);
+    ASSERT_EQ(nonExistantKeyValue.has_value(), false);
 }

--- a/src/ConfigTest.cpp
+++ b/src/ConfigTest.cpp
@@ -422,3 +422,35 @@ TEST_F(ConfigTest, configWorksWithJsonAndXml)
     ASSERT_EQ(userNameValue, "Koko");
     ASSERT_EQ(userActiveValue, false);
 }
+
+TEST_F(ConfigTest, givenCxxEnvAndConfigDir_returnsOptionalKeyValues)
+{
+    EnvironmentSetter::setEnvironmentVariable("CXX_ENV", "test");
+    EnvironmentSetter::setEnvironmentVariable("CXX_CONFIG_DIR", testConfigDirectory.string());
+
+    const auto awsAccountId = "9999999999";
+    const auto awsAccountKey = "806223445";
+
+    EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_ID", awsAccountId);
+    EnvironmentSetter::setEnvironmentVariable("AWS_ACCOUNT_KEY", awsAccountKey);
+
+    Config config;
+
+    const std::string dbHostKey = "db.host";
+    const std::string dbPortKey = "db.port";
+    const std::string awsAccountIdKey = "aws.accountId";
+    const std::string awsAccountKeyKey = "aws.accountKey";
+    const std::string nonExistantKey = "redis.host";
+
+    const auto dbHostValue = config.getOptional<std::string>(dbHostKey);
+    const auto dbPortValue = config.getOptional<int>(dbPortKey);
+    const auto awsAccountIdValue = config.getOptional<std::string>(awsAccountIdKey);
+    const auto awsAccountKeyValue = config.getOptional<std::string>(awsAccountKeyKey);
+    const auto nonExistantKeyValue = config.getOptional<std::string>(nonExistantKey);
+
+    ASSERT_EQ(dbHostValue, "localhost");
+    ASSERT_EQ(dbPortValue, 1996);
+    ASSERT_EQ(awsAccountIdValue, awsAccountId);
+    ASSERT_EQ(awsAccountKeyValue, awsAccountKey);
+    ASSERT_EQ(nonExistantKeyValue, std::nullopt);
+}


### PR DESCRIPTION
Added `std::optional<T> getOptional<T>(const std::string& key)` for getting optional values.
If key does not exist or is null it should return std::nullopt, otherwise value with type T it is castable to that